### PR TITLE
Replace fire function by dispatch

### DIFF
--- a/src/CacheableEloquent.php
+++ b/src/CacheableEloquent.php
@@ -217,7 +217,7 @@ trait CacheableEloquent
         // event set individually instead of catching event for all the models.
         $event = "eloquent.{$event}: ".static::class;
 
-        $method = $halt ? 'until' : 'fire';
+        $method = $halt ? 'until' : 'dispatch';
 
         return static::$dispatcher->{$method}($event, static::class);
     }


### PR DESCRIPTION
fire function is removed now and we can use dispatch for more details please check this [MR](https://github.com/laravel/framework/pull/26392)

fix #24