### PR TITLE
Fix removed Method

### DIFF
--- a/src/CacheableEloquent.php
+++ b/src/CacheableEloquent.php
@@ -217,7 +217,7 @@ trait CacheableEloquent
         // event set individually instead of catching event for all the models.
         $event = "eloquent.{$event}: ".static::class;
 
-        $method = $halt ? 'until' : 'fire';
+        $method = $halt ? 'until' : 'dispatch';
 
         return static::$dispatcher->{$method}($event, static::class);
     }


### PR DESCRIPTION
Change method for dispatching. Fixes breakage with Laravel 5.8, see https://github.com/laravel/framework/pull/26392 and https://laravel.com/docs/5.8/upgrade. See also related bug in laravel-categorizable https://github.com/rinvex/laravel-categories/issues/46.
